### PR TITLE
Rename plugin entrypoint from "mkdocs/exporter" to "exporter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ pip install mkdocs-exporter
 
 Three plugins are currently available:
 
-- `mkdocs/exporter` (*required*): base plugin which must precede the others
-- `mkdocs/exporter/pdf` (*optional*): plugin that exports your pages as individual PDF documents
-- `mkdocs/exporter/extras` (*optional*): provides extra functionalities (buttons, HTML utilities...)
+- `exporter` (*required*): base plugin which must precede the others
+- `exporter-pdf` (*optional*): plugin that exports your pages as individual PDF documents
+- `exporter-extras` (*optional*): provides extra functionalities (buttons, HTML utilities...)
 
 ### Example
 
@@ -66,15 +66,15 @@ The following configuration excerpt from [`mkdocs.yml`](./mkdocs.yml) should cov
 
 ```yaml
 plugins:
-  - mkdocs/exporter
-  - mkdocs/exporter/pdf:
+  - exporter
+  - exporter-pdf:
       concurrency: 8
       covers:
         front: resources/templates/covers/front.html.j2
         back: resources/templates/covers/back.html.j2
       stylesheets:
         - resources/stylesheets/pdf.scss
-  - mkdocs/exporter/extras:
+  - exporter-extras:
       buttons:
         - title: Download as PDF
           enabled: !!python/name:mkdocs_exporter.plugins.pdf.button.enabled

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ You can now register the plugin in your configuration file:
 
 ```yaml
 plugins:
-  - mkdocs/exporter
+  - exporter
 ```
 
 Check out the [setup guides](../setup/setting-up-documents) for more details about how to use and configure the plugin.

--- a/docs/setup/setting-up-buttons.md
+++ b/docs/setup/setting-up-buttons.md
@@ -18,12 +18,12 @@ You can define custom buttons at the top of your pages.
 
 ## Configuration
 
-This feature is provided by the `mkdocs/exporter/extras` plugin, you'll need to add it to your list of plugins:
+This feature is provided by the `exporter-extras` plugin, you'll need to add it to your list of plugins:
 
 ```yaml
 plugins:
-  - mkdocs/exporter
-  - mkdocs/exporter/extras
+  - exporter
+  - exporter-extras
 ```
 
 ## Usage
@@ -34,7 +34,7 @@ This example will add a download button at the top of all pages that have a corr
 
 ```yaml
 plugins:
-  - mkdocs/exporter/extras:
+  - exporter-extras:
       buttons:
         - title: Download as PDF
           icon: material-file-download-outline
@@ -71,7 +71,7 @@ Then, we can define the button and specify the path to the previously defined fu
 
 ```yaml
 plugins:
-  - mkdocs/exporter/extras:
+  - exporter-extras:
       buttons:
         - title: Search on Google
           icon: material-google

--- a/docs/setup/setting-up-documents.md
+++ b/docs/setup/setting-up-documents.md
@@ -24,12 +24,12 @@ playwright install --with-deps
 
 ## Configuration
 
-First of all, you'll need to register the `mkdocs/exporter/pdf` plugin (**after** the `mkdocs/exporter` one) to your configuration:
+First of all, you'll need to register the `exporter-pdf` plugin (**after** the `exporter` one) to your configuration:
 
 ```yaml
 plugins:
-  - mkdocs/exporter
-  - mkdocs/exporter/pdf
+  - exporter
+  - exporter-pdf
 ```
 
 ???+ question "Why multiple plugins?"
@@ -39,7 +39,7 @@ plugins:
     This architecture reduces code duplication and maintains a generic base that can be used to export
     your pages to formats other than PDF (although this is currently the only format supported).
 
-    To sum things up, the `mkdocs/exporter` should always be registered first as it provides a common ground for
+    To sum things up, the `exporter` should always be registered first as it provides a common ground for
     other plugins to rely on.
 
 ## Usage
@@ -51,8 +51,8 @@ This feature is particularly useful during your development processes: when you 
 
 ```yaml
 plugins:
-  - mkdocs/exporter
-  - mkdocs/exporter/pdf:
+  - exporter
+  - exporter-pdf:
       enabled: ![MKDOCS_EXPORTER_ENABLED, true]
 ```
 
@@ -73,8 +73,8 @@ Here's how cover pages are set up for this documentation.
 
     ```yaml
     plugins:
-      - mkdocs/exporter
-      - mkdocs/exporter/pdf:
+      - exporter
+      - exporter-pdf:
           stylesheets:
             - resources/stylesheets/pdf.scss
           covers:
@@ -136,7 +136,7 @@ You may want to override the default value of **4**, depending on your hardware.
 
 ```yaml
 plugins:
-  - mkdocs/exporter/pdf:
+  - exporter-pdf:
       concurrency: 16
 ```
 
@@ -163,7 +163,7 @@ This behaviour is called the `explicit` mode, it can be enabled in your configur
 
 ```yaml
 plugins:
-  - mkdocs/exporter/pdf:
+  - exporter-pdf:
       explicit: true
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,8 +39,8 @@ extra:
       link: https://pypi.org/project/mkdocs-exporter
 
 plugins:
-  - mkdocs/exporter:
-  - mkdocs/exporter/pdf:
+  - exporter:
+  - exporter-pdf:
       concurrency: 16
       stylesheets:
         - resources/stylesheets/pdf.scss
@@ -50,7 +50,7 @@ plugins:
       browser:
         debug: false
         headless: true
-  - mkdocs/exporter/extras:
+  - exporter-extras:
       buttons:
         - title: Download as PDF
           icon: material-file-download-outline

--- a/mkdocs_exporter/plugin.py
+++ b/mkdocs_exporter/plugin.py
@@ -3,6 +3,7 @@ from mkdocs_exporter.page import Page
 from mkdocs.plugins import event_priority
 from mkdocs_exporter.config import Config
 from mkdocs.structure.files import File, Files
+from mkdocs_exporter.logging import logger
 from mkdocs_exporter.preprocessor import Preprocessor
 from mkdocs_exporter.themes.factory import Factory as ThemeFactory
 
@@ -69,3 +70,11 @@ class Plugin(BasePlugin[Config]):
         content = self.theme.stylesheet(reader.read())
       with open(stylesheet.abs_dest_path, 'w+', encoding='utf-8') as writer:
         writer.write(content)
+
+
+class PluginDeprecated(Plugin):
+  def on_config(self, config: dict) -> None:
+    logger.warning(
+      "The plugin name 'mkdocs/exporter/extras' will stop working soon, please replace it with 'exporter-extras'"
+    )
+    super().on_config(config)

--- a/mkdocs_exporter/plugins/extras/plugin.py
+++ b/mkdocs_exporter/plugins/extras/plugin.py
@@ -3,6 +3,7 @@ from collections import UserDict
 from mkdocs.plugins import BasePlugin
 from mkdocs_exporter.page import Page
 from mkdocs.plugins import event_priority
+from mkdocs_exporter.logging import logger
 from mkdocs_exporter.preprocessor import Preprocessor
 from mkdocs_exporter.plugins.extras.config import Config
 
@@ -37,3 +38,10 @@ class Plugin(BasePlugin[Config]):
         preprocessor.button(**resolve(button))
 
     return preprocessor.done()
+
+
+class PluginDeprecated(Plugin):
+  def on_config(self, config: dict) -> None:
+    logger.warning(
+      "The plugin name 'mkdocs/exporter' will stop working soon, please replace it with 'exporter'"
+    )

--- a/mkdocs_exporter/plugins/pdf/plugin.py
+++ b/mkdocs_exporter/plugins/pdf/plugin.py
@@ -100,7 +100,7 @@ class Plugin(BasePlugin[Config]):
     if not self._enabled():
       return
     if not hasattr(page, 'html'):
-      raise Exception('Missing `mkdocs/exporter` plugin or your plugins are not ordered properly!')
+      raise Exception('Missing `exporter` plugin or your plugins are not ordered properly!')
 
     directory = os.path.dirname(page.file.abs_dest_path)
     filename = os.path.splitext(os.path.basename(page.file.abs_dest_path))[0] + '.pdf'
@@ -168,3 +168,12 @@ class Plugin(BasePlugin[Config]):
       return False
 
     return True
+
+
+
+class PluginDeprecated(Plugin):
+  def on_config(self, config: dict) -> None:
+    logger.warning(
+      "The plugin name 'mkdocs/exporter/pdf' will stop working soon, please replace it with 'exporter-pdf'"
+    )
+    super().on_config(config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,12 @@ importlib-metadata = ">=6.0"
 nest-asyncio = ">=1.5.6"
 
 [tool.poetry.plugins."mkdocs.plugins"]
-"mkdocs/exporter" = "mkdocs_exporter.plugin:Plugin"
-"mkdocs/exporter/pdf" = "mkdocs_exporter.plugins.pdf.plugin:Plugin"
-"mkdocs/exporter/extras" = "mkdocs_exporter.plugins.extras.plugin:Plugin"
+"exporter" = "mkdocs_exporter.plugin:Plugin"
+"exporter-pdf" = "mkdocs_exporter.plugins.pdf.plugin:Plugin"
+"exporter-extras" = "mkdocs_exporter.plugins.extras.plugin:Plugin"
+"mkdocs/exporter" = "mkdocs_exporter.plugin:PluginDeprecated"
+"mkdocs/exporter/pdf" = "mkdocs_exporter.plugins.pdf.plugin:PluginDeprecated"
+"mkdocs/exporter/extras" = "mkdocs_exporter.plugins.extras.plugin:PluginDeprecated"
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/adrienbrignon/mkdocs-exporter/issues"


### PR DESCRIPTION
Keep old names working but with a warning.

Slashes are reserved for theme-specific plugins, and this plugin is not specific to the "mkdocs" theme.
