### PR TITLE
fix(pdf/aggregator): avoid 'limits' cover skips with only one page

### DIFF
--- a/mkdocs_exporter/formats/pdf/aggregator.py
+++ b/mkdocs_exporter/formats/pdf/aggregator.py
@@ -44,7 +44,9 @@ class Aggregator:
       elif covers == 'back':
         self._skip(page, ['front'])
       elif covers == 'limits':
-        if index == 0:
+        if len(self.pages) == 1:
+          pass
+        elif index == 0:
           self._skip(page, ['back'])
         elif index == (len(self.pages) - 1):
           self._skip(page, ['front'])


### PR DESCRIPTION
If `covers: limits` is used, but one of the website using this configuration only has one enabled page,  
the back cover is missing in the resulting PDF documentation.

Example : 

```yaml
# Pages plugins
plugins:
  - ...
  - exporter:
      formats:
        pdf:
          ...
          aggregator:
            ...
            covers: limits
```