### PR TITLE
📝 Copy Background Image when using Global Front Cover page

### DIFF
--- a/docs/configuration/generating-pdf-documents.md
+++ b/docs/configuration/generating-pdf-documents.md
@@ -169,6 +169,8 @@ This ensures a consistent look and feel across all your PDF documents without ne
 
     > :material-file-code: View the full content of this file [here](https://github.com/adrienbrignon/mkdocs-exporter/blob/master/resources/stylesheets/pdf.scss).
 
+If you use the template **front cover page**, do not forget to copy the  [background image](https://raw.githubusercontent.com/adrienbrignon/mkdocs-exporter/master/docs/assets/images/background.png)  `docs/assets/images/background.png` to your project.
+
 #### Per-page cover pages
 
 While global cover pages provide a uniform look across your documentation, you can override them on a per-page basis using front matter.  


### PR DESCRIPTION
This PR 
- reminds that copying the background image is required when using the global front cover page.
- updates the  [`Generating PDF Documents` page](https://adrienbrignon.github.io/mkdocs-exporter/configuration/generating-pdf-documents/#global-cover-pages).

This will prevent getting cryptic errors saying that a file cannot be loaded and causing the build to timeout.