### PR TITLE
feat(pdf/aggregator): implement 'book' covers to have 'limits' + 'fronts'

### DIFF
--- a/docs/configuration/generating-pdf-documents.md
+++ b/docs/configuration/generating-pdf-documents.md
@@ -262,6 +262,7 @@ There are five available options for managing cover pages:
 - `all` (*default*): retains every cover page from all documents.
 - `none`: removes every cover page from the aggregated document, resulting in a compilation that includes only the main content of each PDF.
 - `limits`: retains the front cover of the first document and the back cover of the last document, while removing all other cover pages in between.
+- `book`: retains the front cover of the first document and the back cover of the last document, while keeping only the front cover pages in between.
 - `front`: preserves every front cover page from all documents but removes all back cover pages.
 - `back`: preserves every back cover page from all documents but removes all front cover pages.
 

--- a/mkdocs_exporter/formats/pdf/aggregator.py
+++ b/mkdocs_exporter/formats/pdf/aggregator.py
@@ -52,6 +52,13 @@ class Aggregator:
           self._skip(page, ['front'])
         else:
           self._skip(page, ['front', 'back'])
+      elif covers == 'book':
+        if len(self.pages) == 1:
+          pass
+        elif index == 0:
+          self._skip(page, ['back'])
+        elif index < (len(self.pages) - 1):
+          self._skip(page, ['back'])
 
     return self
 

--- a/mkdocs_exporter/formats/pdf/config.py
+++ b/mkdocs_exporter/formats/pdf/config.py
@@ -40,7 +40,7 @@ class AggregatorConfig(BaseConfig):
   metadata = c.Type(dict, default={})
   """Some metadata to append to the PDF document."""
 
-  covers = c.Choice(['all', 'none', 'limits', 'front', 'back'], default='all')
+  covers = c.Choice(['all', 'none', 'limits', 'book', 'front', 'back'], default='all')
   """The behavior of cover pages."""
 
 


### PR DESCRIPTION
To extend the 'limits' aggregator, I needed to preserve the 'chapters' front covers to isolate each page's documentation title / version / ...

If `book` is not ideal, feel free to request another specific name :+1: .