### PR TITLE
Minor fixes for `mkdocs serve` rebuild and others

### DIFF
--- a/mkdocs_exporter/formats/pdf/browser.py
+++ b/mkdocs_exporter/formats/pdf/browser.py
@@ -35,7 +35,14 @@ class Browser:
     self.context = None
     self._launched = False
     self.playwright = None
-    self.lock = asyncio.Lock()
+    try:
+      self.lock = asyncio.Lock()
+    except RuntimeError as e:
+      if 'no current event loop' in str(e):
+        asyncio.set_event_loop(asyncio.new_event_loop())
+        self.lock = asyncio.Lock()
+      else:
+        raise
     self.debug = options.get('debug', False)
     self.headless = options.get('headless', True)
     self.timeout = options.get('timeout', 60_000)

--- a/mkdocs_exporter/formats/pdf/plugin.py
+++ b/mkdocs_exporter/formats/pdf/plugin.py
@@ -184,9 +184,15 @@ class Plugin(BasePlugin[Config]):
 
     for page in self.pages:
       self.aggregator.append(page.formats['pdf']['path'] + '.aggregate')
-      os.unlink(page.formats['pdf']['path'] + '.aggregate')
 
     self.aggregator.save()
+
+    for page in self.pages:
+      try:
+        os.unlink(page.formats['pdf']['path'] + '.aggregate')
+      except FileNotFoundError:
+        pass
+
 
 
   @event_priority(-100)
@@ -225,6 +231,8 @@ class Plugin(BasePlugin[Config]):
 
     for index, page in enumerate(self.pages):
       page.index = index
+      if not hasattr(page, 'formats'):
+        page.formats = {}
 
 
   def _enabled(self, page: Page = None) -> bool:

--- a/mkdocs_exporter/formats/pdf/plugin.py
+++ b/mkdocs_exporter/formats/pdf/plugin.py
@@ -194,7 +194,6 @@ class Plugin(BasePlugin[Config]):
         pass
 
 
-
   @event_priority(-100)
   def _on_post_build_3(self, **kwargs) -> None:
     """Invoked after the build process."""


### PR DESCRIPTION
- Added check for the `no current event loop` exception thrown by asyncio on rebuild (#47)
- Delayed file cleanup for the pdf aggregator to avoid deleting files before the PDF is saved. (#51)
- Guarantee the creation of the `pdf.pages[].formats` property (#48)